### PR TITLE
Changed mode on validators to after

### DIFF
--- a/src/caf/space/inputs.py
+++ b/src/caf/space/inputs.py
@@ -60,13 +60,13 @@ class ZoneSystemInfo(BaseConfig):
     shapefile: Path
     id_col: str
 
-    @model_validator(mode="before")
+    @model_validator(mode="after")
     def _id_col_in_file(cls, values):
-        with fiona.collection(values["shapefile"]) as source:
+        with fiona.collection(values.shapefile) as source:
             schema = source.schema
-            if values["id_col"] not in schema["properties"].keys():
+            if values.id_col not in schema["properties"].keys():
                 raise ValueError(
-                    f"The id_col provided, {values['id_col']}, does not appear"
+                    f"The id_col provided, {values.id_col}, does not appear"
                     f" in the given shapefile. Please choose from:"
                     f"{schema['properties'].keys()}."
                 )
@@ -136,10 +136,10 @@ class LowerZoneSystemInfo(ZoneSystemInfo):
             raise FileNotFoundError(f"The weight data path provided for {v} does not exist.")
         return v
 
-    @model_validator(mode="before")
+    @model_validator(mode="after")
     def _valid_data_col(cls, values):
-        cols = pd.read_csv(values["weight_data"], nrows=1).columns
-        for v in [values["data_col"], values["weight_id_col"]]:
+        cols = pd.read_csv(values.weight_data, nrows=1).columns
+        for v in [values.data_col, values.weight_id_col]:
             if v not in cols:
                 raise ValueError(f"The given col, {v}, does not appear in the weight data.")
         return values


### PR DESCRIPTION
Ensures 'values' will always be an instance of the class itself, rather than a dict containing values.

Describe Changes
---

Updated model_validators to validate 'after' rather than 'before' for consistency.

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `setup.cfg`
- [ ] Have any new features been properly integrated with the API (CLI and GUI)?
