### PR TITLE
Filter weighting data to just keep the weighting column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ venv.bak/
 # Pycharm project settings
 .idea
 
+# VS Code settings
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/src/caf/space/ui.py
+++ b/src/caf/space/ui.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 "User interface for caf.space."
+
 # Built-Ins
 import logging
 import sys

--- a/src/caf/space/utils.py
+++ b/src/caf/space/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Module for some miscellaneous functions used elsewhere."""
+
 # Built-Ins
 from pathlib import Path
 

--- a/src/caf/space/weighted_funcs.py
+++ b/src/caf/space/weighted_funcs.py
@@ -49,7 +49,7 @@ def _weighted_lower(
         weighting = pd.read_csv(
             lower_zoning.weight_data,
             index_col=lower_zoning.weight_id_col,
-        )
+        )[lower_zoning.data_col]
         weighted = lower_zone.join(weighting)
     else:
         weighted = lower_zone

--- a/src/caf/space/weighted_funcs.py
+++ b/src/caf/space/weighted_funcs.py
@@ -49,7 +49,7 @@ def _weighted_lower(
         weighting = pd.read_csv(
             lower_zoning.weight_data,
             index_col=lower_zoning.weight_id_col,
-            usecols=[lower_zoning.data_col,lower_zoning.weight_id_col]
+            usecols=[lower_zoning.data_col, lower_zoning.weight_id_col],
         )
         weighted = lower_zone.join(weighting)
     else:

--- a/src/caf/space/weighted_funcs.py
+++ b/src/caf/space/weighted_funcs.py
@@ -49,7 +49,8 @@ def _weighted_lower(
         weighting = pd.read_csv(
             lower_zoning.weight_data,
             index_col=lower_zoning.weight_id_col,
-        )[lower_zoning.data_col]
+            usecols=[lower_zoning.data_col,lower_zoning.weight_id_col]
+        )
         weighted = lower_zone.join(weighting)
     else:
         weighted = lower_zone

--- a/src/caf/space/zone_translation.py
+++ b/src/caf/space/zone_translation.py
@@ -5,6 +5,7 @@ Module containing ZoneTranslation class.
 Class for producing zone translations from a set of inputs, provided by the
 ZoneTranslationInputs class in 'inputs'.
 """
+
 # Built-Ins
 import logging
 import warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 """
 Fixtures used across multiple test modules.
 """
+
 # Built-Ins
 from copy import deepcopy
 from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,7 @@ def fixture_lower_zone(main_dir) -> Path:
     lower.to_file(file)
     return file
 
+
 @pytest.fixture(name="lower_zone_duplicate_cols", scope="session")
 def fixture_lower_zone_duplicate_cols(main_dir) -> Path:
     """
@@ -86,7 +87,7 @@ def fixture_lower_zone_duplicate_cols(main_dir) -> Path:
     Returns:
         Path: Temp path to gdf, 16 attributes, 1-17, ID_COL = lower_id
     """
-    lower_df = pd.DataFrame(data={"lower_id": range(1, 17), "duplicate": range(1,17)})
+    lower_df = pd.DataFrame(data={"lower_id": range(1, 17), "duplicate": range(1, 17)})
     lower = gpd.GeoDataFrame(
         data=lower_df,
         geometry=[
@@ -113,6 +114,7 @@ def fixture_lower_zone_duplicate_cols(main_dir) -> Path:
     file = main_dir / "lower_zone_duplicate_col.shp"
     lower.to_file(file)
     return file
+
 
 @pytest.fixture(name="zone_1_shape", scope="session")
 def fixture_zone_1_shape(main_dir) -> Path:
@@ -249,6 +251,7 @@ def fixture_lower_weighting(main_dir) -> Path:
     weighting.to_csv(main_dir / "weighting.csv")
     return file
 
+
 @pytest.fixture(name="lower_weighting_duplicate_cols", scope="session")
 def fixture_lower_weighting_duplicate_cols(main_dir) -> Path:
     """
@@ -293,6 +296,7 @@ def fixture_lower_weighting_duplicate_cols(main_dir) -> Path:
     file = main_dir / "weighting_duplicate_cols.csv"
     weighting.to_csv(main_dir / "weighting_duplicate_cols.csv")
     return file
+
 
 @pytest.fixture(name="paths", scope="session")
 def fixture_paths(main_dir, tmp_path_factory) -> dict[str, Path]:
@@ -414,6 +418,7 @@ def fixture_weighted_config(
         rounding=True,
     )
     return params
+
 
 @pytest.fixture(name="weighted_config_duplicate_cols", scope="session")
 def fixture_weighted_config_duplicate_cols(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,40 @@ def fixture_lower_zone(main_dir) -> Path:
     lower.to_file(file)
     return file
 
+@pytest.fixture(name="lower_zone_duplicate_cols", scope="session")
+def fixture_lower_zone_duplicate_cols(main_dir) -> Path:
+    """
+    Lower zone system for testing with an extra column with the same name as weighting.
+    Returns:
+        Path: Temp path to gdf, 16 attributes, 1-17, ID_COL = lower_id
+    """
+    lower_df = pd.DataFrame(data={"lower_id": range(1, 17), "duplicate": range(1,17)})
+    lower = gpd.GeoDataFrame(
+        data=lower_df,
+        geometry=[
+            Polygon([(0, 0), (0, 2), (2, 2), (2, 0)]),
+            Polygon([(0, 2), (0, 4), (2, 4), (2, 2)]),
+            Polygon([(0, 4), (0, 6), (2, 6), (2, 4)]),
+            Polygon([(0, 6), (0, 8), (2, 8), (2, 6)]),
+            Polygon([(2, 0), (2, 2), (4, 2), (4, 0)]),
+            Polygon([(2, 2), (2, 4), (4, 4), (4, 2)]),
+            Polygon([(2, 4), (2, 6), (4, 6), (4, 4)]),
+            Polygon([(2, 6), (2, 8), (4, 8), (4, 6)]),
+            Polygon([(4, 0), (4, 2), (6, 2), (6, 0)]),
+            Polygon([(4, 2), (4, 4), (6, 4), (6, 2)]),
+            Polygon([(4, 4), (4, 6), (6, 6), (6, 4)]),
+            Polygon([(4, 6), (4, 8), (6, 8), (6, 6)]),
+            Polygon([(6, 0), (6, 2), (8, 2), (8, 0)]),
+            Polygon([(6, 2), (6, 4), (8, 4), (8, 2)]),
+            Polygon([(6, 4), (6, 6), (8, 6), (8, 4)]),
+            Polygon([(6, 6), (6, 8), (8, 8), (8, 6)]),
+        ],
+        crs="EPSG:27700",
+    )
+    lower.geometry = lower.geometry.rotate(270, origin=[4, 4])
+    file = main_dir / "lower_zone_duplicate_col.shp"
+    lower.to_file(file)
+    return file
 
 @pytest.fixture(name="zone_1_shape", scope="session")
 def fixture_zone_1_shape(main_dir) -> Path:
@@ -215,6 +249,50 @@ def fixture_lower_weighting(main_dir) -> Path:
     weighting.to_csv(main_dir / "weighting.csv")
     return file
 
+@pytest.fixture(name="lower_weighting_duplicate_cols", scope="session")
+def fixture_lower_weighting_duplicate_cols(main_dir) -> Path:
+    """
+    Weighting data to be joined to lower zoning system for testing.
+
+    Parameters
+    ----------
+    main_dir
+
+    Returns
+    -------
+    Path: Temp path to weighting data in a column called 'weight', with an
+    index called 'lower_id', matching lower_id in lower shape.
+
+    """
+    values = [
+        10,
+        20,
+        20,
+        30,
+        20,
+        10,
+        10,
+        10,
+        30,
+        20,
+        20,
+        30,
+        30,
+        30,
+        10,
+        10,
+    ]
+    weighting = pd.DataFrame(
+        data={
+            "weight": values,
+            "duplicate": values,
+        },
+        index=range(1, 17),
+    )
+    weighting.index.name = "lower_id"
+    file = main_dir / "weighting_duplicate_cols.csv"
+    weighting.to_csv(main_dir / "weighting_duplicate_cols.csv")
+    return file
 
 @pytest.fixture(name="paths", scope="session")
 def fixture_paths(main_dir, tmp_path_factory) -> dict[str, Path]:
@@ -321,6 +399,57 @@ def fixture_weighted_config(
         shapefile=lower_zone,
         id_col="lower_id",
         weight_data=lower_weighting,
+        data_col="weight",
+        weight_id_col="lower_id",
+        weight_data_year=2018,
+    )
+    params = inputs.ZoningTranslationInputs(
+        zone_1=zone_1,
+        zone_2=zone_2,
+        lower_zoning=lower,
+        output_path=paths["output"],
+        cache_path=paths["cache"],
+        method="test",
+        tolerance=0.99,
+        rounding=True,
+    )
+    return params
+
+@pytest.fixture(name="weighted_config_duplicate_cols", scope="session")
+def fixture_weighted_config_duplicate_cols(
+    zone_1_shape: Path,
+    zone_2_shape: Path,
+    lower_zone_duplicate_cols: Path,
+    lower_weighting_duplicate_cols: Path,
+    paths: dict,
+) -> inputs.ZoningTranslationInputs:
+    """
+    The config for a test weighted translation. This config is used as
+    a base for other weighted test cases.
+    Parameters
+    ----------
+    Params are all inherited from fixtures.
+    zone_1_shape
+    zone_2_shape
+    lower_zone
+    lower_weighting
+    paths
+
+    Returns
+    -------
+    An input config for running a basic weighted zone translation.
+    """
+    zone_1 = inputs.TransZoneSystemInfo(
+        name="zone_1", shapefile=zone_1_shape, id_col="zone_1_id"
+    )
+    zone_2 = inputs.TransZoneSystemInfo(
+        name="zone_2", shapefile=zone_2_shape, id_col="zone_2_id"
+    )
+    lower = inputs.LowerZoneSystemInfo(
+        name="lower_zone",
+        shapefile=lower_zone_duplicate_cols,
+        id_col="lower_id",
+        weight_data=lower_weighting_duplicate_cols,
         data_col="weight",
         weight_id_col="lower_id",
         weight_data_year=2018,

--- a/tests/test_weighted_funcs.py
+++ b/tests/test_weighted_funcs.py
@@ -99,7 +99,10 @@ class TestWeightedLower:
     """
     Class for testing the _weighted_lower function in weighted_funcs
     """
-    @pytest.mark.parametrize("config_fixture", ["weighted_config", "weighted_config_duplicate_cols"])
+
+    @pytest.mark.parametrize(
+        "config_fixture", ["weighted_config", "weighted_config_duplicate_cols"]
+    )
     def test_join(self, config_fixture, request):
         """
         Check that weighting is correct after join in the _weighted_lower
@@ -130,7 +133,6 @@ class TestWeightedLower:
             match="1 zones do not match up between the lower zoning and weighting data.",
         ):
             weighted_funcs._weighted_lower(mismatched_config.lower_zoning)
-
 
 
 class TestCreateTiles:

--- a/tests/test_weighted_funcs.py
+++ b/tests/test_weighted_funcs.py
@@ -99,11 +99,13 @@ class TestWeightedLower:
     """
     Class for testing the _weighted_lower function in weighted_funcs
     """
-
-    def test_join(self, weighted):
+    @pytest.mark.parametrize("config_fixture", ["weighted_config", "weighted_config_duplicate_cols"])
+    def test_join(self, config_fixture, request):
         """
         Check that weighting is correct after join in the _weighted_lower
         """
+        config = request.getfixturevalue(config_fixture)
+        weighted = weighted_funcs._weighted_lower(config.lower_zoning)
         summed = weighted.weight.sum()
         assert summed == 310
 
@@ -128,6 +130,7 @@ class TestWeightedLower:
             match="1 zones do not match up between the lower zoning and weighting data.",
         ):
             weighted_funcs._weighted_lower(mismatched_config.lower_zoning)
+
 
 
 class TestCreateTiles:


### PR DESCRIPTION
# Changes

Filter weighting data on read in to prevent join error when joining to lower zoning.

- Closes #58  *(replace XXXX with GitHub issue number)*
- ...

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass
