### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.space/security/code-scanning/3](https://github.com/Transport-for-the-North/caf.space/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (best here since there is one job and all steps share similar needs).  
Use least privilege: `contents: read` is the minimal and appropriate baseline for checkout and test execution. This preserves existing functionality while preventing unintended write scopes if repo/org defaults change.

**File to change:** `.github/workflows/tests.yml`  
**Region:** after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are required—just YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
