### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.space/security/code-scanning/2](https://github.com/Transport-for-the-North/caf.space/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/black.yml` at the workflow root so it applies to all jobs (currently just `format`) without changing behavior.

Best fix here:
- Insert:
  - `permissions:`
  - `  contents: read`
- Place it after the trigger (`on:` block) and before `jobs:` for clarity and standard structure.
- No imports, methods, or other definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
