### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.space/security/code-scanning/1](https://github.com/Transport-for-the-North/caf.space/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/linting.yml` so the workflow does not inherit potentially broader defaults.

Best fix (without changing functionality): set workflow-level permissions to read-only for repository contents, which is sufficient for `actions/checkout` and linting steps in this file.

- **File:** `.github/workflows/linting.yml`
- **Change location:** after the `on:` trigger block and before `jobs:`
- **Add:**
  - `permissions:`
  - `  contents: read`

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
